### PR TITLE
bash completion for tp command

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -56,6 +56,15 @@ Installation is very simple, and requires just a few steps, as shown here:
 5) Now, just start using the tp command to move between directories instead of 
    the cd command.  I hope you'll like it as much as I do.
 
+ENABLE TELEPORT COMPLETION WITH
+-------------------------------
+
+Defaultly the completion will be the same as cd. You can add the handy teleport completion. 
+
+Just copy the completion file to the bashcompletion list
+
+``cp completion /etc/bash_completion.d/teleport``
+
 
 TELEPORT HELP
 -------------

--- a/INSTALL
+++ b/INSTALL
@@ -63,7 +63,7 @@ Defaultly the completion will be the same as cd. You can add the handy teleport 
 
 Just copy the completion file to the bashcompletion list
 
-``cp completion /etc/bash_completion.d/teleport``
+    cp completion /etc/bash_completion.d/teleport
 
 
 TELEPORT HELP

--- a/INSTALL
+++ b/INSTALL
@@ -56,8 +56,8 @@ Installation is very simple, and requires just a few steps, as shown here:
 5) Now, just start using the tp command to move between directories instead of 
    the cd command.  I hope you'll like it as much as I do.
 
-ENABLE TELEPORT COMPLETION WITH
--------------------------------
+ENABLE TELEPORT COMPLETION
+--------------------------
 
 Defaultly the completion will be the same as cd. You can add the handy teleport completion. 
 

--- a/completion
+++ b/completion
@@ -10,26 +10,21 @@ _teleport-command()
 
     opts=""
 
-#    if [ -z "$cur" ]; then
-#     cur="."
-#    fi
-
     # HISTORY COMPLETION
     while read i; do
      opts="$opts $(basename $i)"
     done < ~/.tp_history
 
     # CURRENT DIR COMPLETION
-
     if [ -z "$cur" ]; then
      cdir="."
     elif [[ "${cur:${#cur} - 1}" == '/' ]]; then
      cdir="$cur"
     else
-     cdir=$(dirname ${cur})
+     cdir=$(command dirname ${cur})
     fi
 
-    for i in `ls "$cdir" 2>/dev/null`;  do
+    for i in `command ls "$cdir" 2>/dev/null`;  do
      opts="$opts $(basename $i)"
     done
 

--- a/completion
+++ b/completion
@@ -1,0 +1,42 @@
+# Bash completion for teleport command
+#
+# https://github.com/alvinj/Teleport
+#
+
+_teleport-command()
+{
+    COMPREPLY=()
+    cur=${COMP_WORDS[COMP_CWORD]}
+
+    opts=""
+
+#    if [ -z "$cur" ]; then
+#     cur="."
+#    fi
+
+    # HISTORY COMPLETION
+    while read i; do
+     opts="$opts $(basename $i)"
+    done < ~/.tp_history
+
+    # CURRENT DIR COMPLETION
+
+    if [ -z "$cur" ]; then
+     cdir="."
+    elif [[ "${cur:${#cur} - 1}" == '/' ]]; then
+     cdir="$cur"
+    else
+     cdir=$(dirname ${cur})
+    fi
+
+    for i in `ls "$cdir" 2>/dev/null`;  do
+     opts="$opts $(basename $i)"
+    done
+
+
+
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    return 0
+
+}
+complete -o default -F _teleport-command tp


### PR DESCRIPTION
I just added the ability to access the teleportable directory to the completion. It will read the `~/.tp_history` and put them in the completion list in addition of the default completion 
